### PR TITLE
LoRA tab: add favorites, sorting, and responsive toolbar

### DIFF
--- a/src/app/home/options/options.component.css
+++ b/src/app/home/options/options.component.css
@@ -179,25 +179,49 @@
   flex-wrap: wrap;
 }
 
-.loras-grid {
+.lora-toolbar {
+  display: grid;
+  gap: 12px;
+  align-items: end;
+}
+
+.lora-toolbar__controls {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.lora-toolbar__control .form-label {
+  margin-bottom: 0.25rem;
+}
+
+.lora-toolbar__toggle .form-check {
   display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  /* Space between items */
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.lora-toolbar__toggle .form-check-label {
+  margin: 0;
+}
+
+.loras-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 16px;
   overflow-y: auto;
-  /* Enable scrolling if the content exceeds the height */
   overflow-x: hidden;
-  /* Hide horizontal scrollbar */
 }
 
 .lora-card {
   border: 1px solid #ddd;
   border-radius: 8px;
-  overflow: visible;
-  min-height: 190px;
-  /* Set a minimum height to prevent layout shifts */
-  max-width: 600px;
-  /* Enforce a consistent card width */
+  overflow: hidden;
+  min-height: 230px;
+  background: #fff;
+  position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .lora-image {
@@ -206,6 +230,21 @@
   object-fit: cover;
   object-position: center top;
   /* Align the image towards the top */
+}
+
+.lora-favorite-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  border-radius: 999px;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  z-index: 2;
+}
+
+.lora-favorite-btn i {
+  color: #f5b700;
 }
 
 .lora-info {
@@ -240,7 +279,7 @@
   align-items: center;
   margin-bottom: 10px;
   /* flex-wrap: nowrap; Prevent wrapping */
-  max-width: 30%;
+  max-width: 100%;
   /* Ensure it doesn't exceed the container width */
 }
 
@@ -346,16 +385,20 @@
 }
 
 .lora-card {
-  width: calc(33% - 15px);
-  border: 1px solid #ddd;
+  width: 100%;
   box-sizing: border-box;
 }
 
 .btn.btn-primary.lora-request-btn {
   width: 100%;
+  grid-column: 1 / -1;
 }
 
 @media (max-width: 768px) {
+  .lora-toolbar__controls {
+    grid-template-columns: 1fr;
+  }
+
   .button-group {
     flex-direction: row;
     width: 100%;
@@ -375,6 +418,10 @@
 }
 
 @media (max-width: 480px) {
+  .loras-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+
   .input-button-container {
     flex-direction: column;
     align-items: flex-start;

--- a/src/app/home/options/options.component.html
+++ b/src/app/home/options/options.component.html
@@ -577,10 +577,33 @@
       [style]="{ width: '100%', marginBottom: '10px' }" (onChange)="filterLoras()">
     </p-multiSelect>
 
-    <!-- Search and Add Custom LoRA -->
-    <div class="d-flex justify-content-between mb-3">
-      <input type="text" class="form-control w-80" placeholder="Search LoRAs..." [(ngModel)]="loraSearchQuery"
-        (ngModelChange)="filterLoras()">
+    <!-- Search + Sort + Favorites -->
+    <div class="lora-toolbar mb-3">
+      <div class="lora-toolbar__search">
+        <label class="form-label">Search LoRAs</label>
+        <input type="text" class="form-control" placeholder="Search by name or version..." [(ngModel)]="loraSearchQuery"
+          (ngModelChange)="filterLoras()">
+      </div>
+      <div class="lora-toolbar__controls">
+        <div class="lora-toolbar__control">
+          <label class="form-label">Sort by</label>
+          <select class="form-select" [(ngModel)]="loraSortOrder" (ngModelChange)="filterLoras()">
+            <option value="most_used">Most used</option>
+            <option value="last_used">Last used</option>
+            <option value="favorites">Favorites first</option>
+            <option value="alpha_asc">Alphabetical A → Z</option>
+            <option value="alpha_desc">Alphabetical Z → A</option>
+          </select>
+        </div>
+        <div class="lora-toolbar__control lora-toolbar__toggle">
+          <label class="form-label">Favorites only</label>
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" role="switch" [(ngModel)]="loraFavoritesOnly"
+              (ngModelChange)="filterLoras()">
+            <span class="form-check-label">Show</span>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Full-Sized Image Dialog -->
@@ -599,6 +622,9 @@
         Request LoRAs!
       </button>
       <div *ngFor="let lora of filteredLoras" class="lora-card">
+        <button class="btn btn-light lora-favorite-btn" type="button" (click)="toggleLoraFavorite(lora, $event)">
+          <i class="bi" [ngClass]="isLoraFavorite(lora) ? 'bi-star-fill' : 'bi-star'"></i>
+        </button>
         <img [src]="lora.image_url" [alt]="lora.name" class="lora-image"
           (click)="openImageModalLoraPreview(lora.image_url)">
         <div class="lora-info">


### PR DESCRIPTION
### Motivation
- Improve the LoRAs panel usability by adding richer filtering and sorting options (last used, favorites, alphabetical) to make selection faster and clearer on desktop and mobile.
- Allow users to mark frequently used LoRAs as favorites and persist usage/favorite state across sessions for better discovery.
- Provide a compact, responsive UI that groups search, sort and favorites controls into a single toolbar and simplifies the LoRA cards layout.

### Description
- Added persisted LoRA preferences: favorites and last-used timestamps stored under `loraFavorites` and `loraLastUsed` in `localStorage`, with helper methods `loadLoraPreferences`, `persistLoraFavorites`, and `persistLoraLastUsed` in `options.component.ts`.
- Introduced new sorting and filtering options (`loraSortOrder`, `loraFavoritesOnly`) and integrated them into `filterLoras`, supporting `most_used`, `last_used`, `favorites`, `alpha_asc`, and `alpha_desc` modes and favorites-only filtering.
- Mark LoRAs as last-used when selected or when loading history via `markLoraLastUsed`, and added per-card favorite toggles with `isLoraFavorite`/`toggleLoraFavorite` and UI wiring in the template.
- Reworked the LoRAs UI: added a toolbar with search/sort/favorites controls, per-card favorite button, and updated CSS for a responsive grid and improved card layout (changes in `options.component.html` and `options.component.css`).

### Testing
- Performed a development build and served the app using `ng serve`, and the build completed successfully.
- Launched a simple Playwright script to open the app and capture a screenshot of the LoRAs panel, which produced `artifacts/loras-tab.png` showing the new UI.
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960571d3478832296daa52df02ea883)